### PR TITLE
PR para viabilizar uso de frameworks de Mock

### DIFF
--- a/impl/src/main/java/br/gov/frameworkdemoiselle/junit/DemoiselleRunner.java
+++ b/impl/src/main/java/br/gov/frameworkdemoiselle/junit/DemoiselleRunner.java
@@ -42,7 +42,6 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
-import br.gov.frameworkdemoiselle.lifecycle.AfterShutdownProccess;
 import br.gov.frameworkdemoiselle.lifecycle.AfterStartupProccess;
 import br.gov.frameworkdemoiselle.util.Beans;
 
@@ -85,7 +84,7 @@ public class DemoiselleRunner extends BlockJUnit4ClassRunner {
 	}
 
 	private void shutdown() {
-		Beans.getBeanManager().fireEvent(new AfterShutdownProccess() {
+		Beans.getBeanManager().fireEvent(new Object() {
 		});
 	}
 }

--- a/impl/src/main/java/br/gov/frameworkdemoiselle/junit/DemoiselleRunner.java
+++ b/impl/src/main/java/br/gov/frameworkdemoiselle/junit/DemoiselleRunner.java
@@ -37,12 +37,12 @@
 package br.gov.frameworkdemoiselle.junit;
 
 import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
-import br.gov.frameworkdemoiselle.lifecycle.AfterStartupProccess;
 import br.gov.frameworkdemoiselle.util.Beans;
 
 public class DemoiselleRunner extends BlockJUnit4ClassRunner {
@@ -66,9 +66,9 @@ public class DemoiselleRunner extends BlockJUnit4ClassRunner {
 	@Override
 	public void run(RunNotifier notifier) {
 		Weld weld = new Weld();
-		weld.initialize();
+		WeldContainer container = weld.initialize();
 
-		this.startup();
+		this.startup(container);
 		super.run(notifier);
 
 		weld.shutdown();
@@ -78,8 +78,9 @@ public class DemoiselleRunner extends BlockJUnit4ClassRunner {
 		return Beans.getReference(getTestClass().getJavaClass());
 	}
 
-	private void startup() {
-		Beans.getBeanManager().fireEvent(new AfterStartupProccess() {
+	private void startup(WeldContainer container) {
+		Beans.setBeanManager(container.getBeanManager());
+		Beans.getBeanManager().fireEvent(new Object() {
 		});
 	}
 


### PR DESCRIPTION
Sugestão de modificação no DemoiselleRunner para viabilizar o uso de framework de mocks, como por exemplo, o Mockito.

Desvincula o DemoiselleRunner dos eventos lançados pelo CDI para o Demoiselle inicializar RequestContext, SessionContext, ViewContext e ConversationContext na classe SeBootstrap. Acredito que estes escopos nem devem fazer parte de um teste JUnit e a tentativa da criação dos mesmos estavam inviabilizando o uso do DemoiselleRunner em testes de unidade com mocks.

Favor avaliar esta correção para próxima versão, @emersonsdo , @zyc , @Dancovich , @ednaraoliveira 
